### PR TITLE
feat: マッピング先のアクションクラス名とメソッド名をリクエストスコープに保存するように修正

### DIFF
--- a/src/main/java/nablarch/integration/router/PathOptionsProviderRoutesMapping.java
+++ b/src/main/java/nablarch/integration/router/PathOptionsProviderRoutesMapping.java
@@ -25,12 +25,21 @@ import java.util.Map;
 public class PathOptionsProviderRoutesMapping extends RoutingHandlerSupport implements Initializable {
     private static final Logger LOGGER = LoggerManager.get(PathOptionsProviderRoutesMapping.class);
 
+    /**
+     * アクションクラス名をリクエストスコープに保存するときのデフォルトのキー。
+     */
+    static final String DEFAULT_REQUEST_MAPPING_CLASS_VAR_NAME = "nablarch_request_mapping_class";
+    /**
+     * アクションクラスのメソッド名をリクエストスコープに保存するときのデフォルトのキー。
+     */
+    static final String DEFAULT_REQUEST_MAPPING_METHOD_VAR_NAME = "nablarch_request_mapping_method";
+
     private final RouteSet routeSet = new RouteSet();
     private String baseUri = "";
     private PathOptionsProvider pathOptionsProvider;
     private PathOptionsFormatter pathOptionsFormatter = new SimplePathOptionsFormatter();
-    private String requestMappingClassVarName = RoutesMapping.DEFAULT_REQUEST_MAPPING_CLASS_VAR_NAME;
-    private String requestMappingMethodVarName = RoutesMapping.DEFAULT_REQUEST_MAPPING_METHOD_VAR_NAME;
+    private String requestMappingClassVarName = DEFAULT_REQUEST_MAPPING_CLASS_VAR_NAME;
+    private String requestMappingMethodVarName = DEFAULT_REQUEST_MAPPING_METHOD_VAR_NAME;
 
     @Override
     protected Class<?> getHandlerClass(HttpRequest request, ExecutionContext executionContext) throws ClassNotFoundException {

--- a/src/test/java/nablarch/integration/router/MockHttpServletRequest.java
+++ b/src/test/java/nablarch/integration/router/MockHttpServletRequest.java
@@ -1,0 +1,35 @@
+package nablarch.integration.router;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * リクエストスコープに設定される値をテストできるようにするためのテストサポートクラス。
+ * <p>
+ * {@link HttpServletRequest}や{@link nablarch.fw.web.servlet.NablarchHttpServletRequestWrapper}を
+ * jmockitでモック化しただけでは、リクエストスコープへの値の出し入れの処理がモック化されてしまい検証ができない。<br>
+ * このクラスはリクエストスコープに保存された値を記録できるように実装しているので、
+ * {@link nablarch.fw.web.servlet.ServletExecutionContext}のコンストラクタでこのインスタンスを渡すことで、
+ * リクエストスコープに保存された値の検証ができるようになる。
+ * </p>
+ * @author Tanaka Tomoyuki
+ */
+public class MockHttpServletRequest extends HttpServletRequestWrapper {
+    private Map<String, Object> requestMap = new HashMap<String, Object>();
+
+    public MockHttpServletRequest(HttpServletRequest request) {
+        super(request);
+    }
+
+    @Override
+    public void setAttribute(String name, Object value) {
+        requestMap.put(name, value);
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+        return requestMap.get(name);
+    }
+}

--- a/src/test/java/nablarch/integration/router/PathOptionsProviderRoutesMappingTest.java
+++ b/src/test/java/nablarch/integration/router/PathOptionsProviderRoutesMappingTest.java
@@ -259,10 +259,10 @@ public class PathOptionsProviderRoutesMappingTest {
 
         sut.getHandlerClass(request, executionContext);
 
-        assertThat((String)executionContext.getRequestScopedVar(RoutesMapping.DEFAULT_REQUEST_MAPPING_CLASS_VAR_NAME),
+        assertThat((String)executionContext.getRequestScopedVar(PathOptionsProviderRoutesMapping.DEFAULT_REQUEST_MAPPING_CLASS_VAR_NAME),
                 is(SimpleAction.class.getName()));
 
-        assertThat((String)executionContext.getRequestScopedVar(RoutesMapping.DEFAULT_REQUEST_MAPPING_METHOD_VAR_NAME),
+        assertThat((String)executionContext.getRequestScopedVar(PathOptionsProviderRoutesMapping.DEFAULT_REQUEST_MAPPING_METHOD_VAR_NAME),
                 is("post"));
     }
 


### PR DESCRIPTION
- 解決したマッピング先のクラス名とメソッド名を、リクエストスコープに保存する修正を追加
    - 現時点での用途は、 nablarch-micrometer-adaptor で取得してリクエスト処理時間のメトリクスのタグとして設定するため
- `RoutesMapping` と `PathOptionsProviderRoutesMapping` の２つを修正
- リクエストスコープに設定するときのデフォルトのキー名は `RoutesMapping` に定数として宣言して、 `PathOptionsProviderRoutesMapping` から利用するようにした
    - ２つのクラスが共通で利用していて、かつこの定数を配置するのにふさわしそうなクラスが見当たらなかったため