### PR TITLE
HTTPリクエストのメトリクス修正の影響でテストがエラーになっていた問題を修正

### DIFF
--- a/src/test/java/nablarch/integration/router/RoutesMappingTest.java
+++ b/src/test/java/nablarch/integration/router/RoutesMappingTest.java
@@ -21,6 +21,7 @@ import net.unit8.http.router.RoutingException;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.servlet.http.HttpServletRequest;
 import java.io.File;
 import java.net.URL;
 import java.util.HashMap;
@@ -43,9 +44,8 @@ public class RoutesMappingTest {
 
     @Mocked
     private HttpRequestWrapper request;
-
     @Mocked
-    private NablarchHttpServletRequestWrapper nablarchRequestWrapper;
+    private HttpServletRequest servletRequest;
 
     private RoutesMapping sut;
     private ServletExecutionContext context;
@@ -67,7 +67,7 @@ public class RoutesMappingTest {
             }
         });
 
-        context = new ServletExecutionContext(null, null, null);
+        context = new ServletExecutionContext(servletRequest, null, null);
     }
 
     /**

--- a/src/test/java/nablarch/integration/router/RoutesMethodBinderTest.java
+++ b/src/test/java/nablarch/integration/router/RoutesMethodBinderTest.java
@@ -5,7 +5,12 @@ import nablarch.fw.ExecutionContext;
 import nablarch.fw.Result;
 import nablarch.fw.web.HttpRequest;
 import nablarch.fw.web.HttpResponse;
+import nablarch.fw.web.servlet.HttpRequestWrapper;
+import nablarch.fw.web.servlet.ServletExecutionContext;
 import org.junit.Test;
+
+import javax.servlet.Servlet;
+import javax.servlet.http.HttpServletRequest;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -17,6 +22,10 @@ public class RoutesMethodBinderTest {
 
     @Mocked
     private HttpRequest request;
+    @Mocked
+    private HttpRequestWrapper requestWrapper;
+    @Mocked
+    private HttpServletRequest servletRequest;
 
     private final ExecutionContext unusedContext = null;
 
@@ -28,8 +37,9 @@ public class RoutesMethodBinderTest {
     public void bindForCorrectMethod() {
 
         final RoutesMethodBinder sut = new RoutesMethodBinder("handle");
+        ServletExecutionContext context = new ServletExecutionContext(servletRequest, null, null);
 
-        String response = (String) sut.bind(new Action()).handle(request, unusedContext);
+        String response = (String) sut.bind(new Action()).handle(request, context);
 
         assertThat(response, is("invoking!!!"));
     }


### PR DESCRIPTION
https://github.com/nablarch/nablarch-fw/commit/1c65641f7b6721188810004fd2de0c182069aa6b#diff-6a4f10cc1d507e9360948e39faea679b344504ae0b2f49c41b3eca8161558f64R143

上記、HTTPリクエストのメトリクスの対応で、 `MethodBinding` の処理の中で `ExecutionContext` を使ってリクエストスコープに情報を保存する修正を入れた。

この結果、以下2クラスのテストが落ちるようになった。

- `RoutesMappingTest`
- `RoutesMethodBinderTest`

## RoutesMappingTest
### テストが落ちる理由
- 修正前は、 `NablarchHttpServletRequestWrapper` をモック化していた
- この `NablarchHttpServletRequestWrapper` は、 `ServletExecutionContext` のコンストラクタで `new` されて、 `servletReq` フィールドにセットされている
    - [ServletExecutionContext()](https://github.com/nablarch/nablarch-fw-web/blob/1.8.0/src/main/java/nablarch/fw/web/servlet/ServletExecutionContext.java#L28)
- リクエストスコープに値を保存するときに、このモック化された `servletReq` から `Map` が取り出される
    - [ExecutionContext#setRequestScopeVar()](https://github.com/nablarch/nablarch-core/blob/1.5.1/src/main/java/nablarch/fw/ExecutionContext.java#L551)
    - [ServletExecutionContext#getRequestScopeMap()](https://github.com/nablarch/nablarch-fw-web/blob/1.8.0/src/main/java/nablarch/fw/web/servlet/ServletExecutionContext.java#L113)
- モックオブジェクトが返す `Map` は、デフォルトで全ての処理が `UnsupportedOperationException` を返すインスタンスになっている
- このため、リクエストスコープに値を設定しようとしたところで `UnsupportedOperationException` が発生して、テストが落ちていた

### 対応
- `NablarchHttpServletRequestWrapper` のモック化を止めて、 `ServletExecutionContext` のコンストラクタで通常のインスタンスが生成されるように変更
    - これによって、 `getRequestScopeMap()` が返す `Map` は普通の `Map` になってエラーが起こらなくなる
- ただし、 `NablarchHttpServletRequestWrapper` のコンストラクタ引数には `null` でない `HttpServletRequest` のインスタンスを渡す必要がある
    - したがって、 `HttpServletRequest` を新たにモック化するように修正した

## RoutesMethodBinderTest
### テストが落ちる理由
- もともとのテストでは、 `ServletExecutionContext` は全く使われない前提だったため、固定で `null` が渡されていた
- 今回の修正で `ServletExecutionContext` を使った処理が追加されたことにより、 `NullPointerException` が発生してエラーとなっていた

### 対応
- エラーとなるテストケースで、 `ServletExecutionContext` をインスタンス化して渡すように修正
    - `RoutesMappingTest` の対応と同じ理由で、 `HttpServletRequest` をモック化している
- また、 `HttpRequestWrapper` もモック化している
    - これは、 `HttpRequestWrapper` のコンストラクタで `getRequestURI()` を使う処理があるが、 `HttpServletRequest` がモック化されているためデフォルトで `null` を返してしまい、 `NullPointerException` が発生するため
        - [HttpRequestWrapper()](https://github.com/nablarch/nablarch-fw-web/blob/1.8.0/src/main/java/nablarch/fw/web/servlet/HttpRequestWrapper.java#L36)
    - テストの本質とは関係ない部分なので、 `HttpRequestWrapper` 自体をモック化して処理が呼ばれないようにしている
