### PR TITLE
@PATCHでのルーティングができるようにする

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>javax.ws.rs-api</artifactId>
-      <version>2.0.1</version>
+      <version>2.1.1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/test/java/nablarch/integration/router/RoutesMappingTest.java
+++ b/src/test/java/nablarch/integration/router/RoutesMappingTest.java
@@ -111,6 +111,26 @@ public class RoutesMappingTest {
     }
 
     /**
+     * PATCHリクエストをマッピングできること。
+     */
+    @Test
+    public void patch() throws Exception {
+
+        new Expectations() {{
+            request.getRequestPath();
+            result = "/method";
+            request.getMethod();
+            result = "PATCH";
+        }};
+
+        Class<?> cls = sut.getHandlerClass(request, context);
+        assertThat(cls.getName(), is(RoutesMappingTestAction.class.getName()));
+
+        context.addHandler(new RoutesMappingTestAction());
+        assertThat((String) context.handleNext(request), is("patch method was invoked."));
+    }
+
+    /**
      * 特別なパラメータである:controllerと:actionを使ったマッピングができること。
      */
     @Test

--- a/src/test/java/nablarch/integration/router/RoutesMappingTestAction.java
+++ b/src/test/java/nablarch/integration/router/RoutesMappingTestAction.java
@@ -20,6 +20,10 @@ public class RoutesMappingTestAction {
         return "post method was invoked.";
     }
 
+    public String patch(HttpRequest request, ExecutionContext context) {
+        return "patch method was invoked.";
+    }
+
     public String controllerAction(HttpRequest request, ExecutionContext context) {
         return "controllerAction method was invoked.";
     }

--- a/src/test/java/nablarch/integration/router/SimplePathOptionsFormatterTest.java
+++ b/src/test/java/nablarch/integration/router/SimplePathOptionsFormatterTest.java
@@ -23,7 +23,8 @@ public class SimplePathOptionsFormatterTest {
             pathOptions("PUT", "/aaa/fizz", "fizz.buzz.Action", "putMethod"),
             pathOptions("POST", "/aaa/fizz", "fizz.buzz.Action", "postMethod"),
             pathOptions("DELETE", "/aaa/fizz", "fizz.buzz.Action", "deleteMethod"),
-            pathOptions("PUT", "/ccc/hoge", "hoge.fuga.Action", "putMethod")
+            pathOptions("PUT", "/ccc/hoge", "hoge.fuga.Action", "putMethod"),
+            pathOptions("PATCH", "/ccc/hoge", "hoge.fuga.Action", "patchMethod")
         );
 
         SimplePathOptionsFormatter sut = new SimplePathOptionsFormatter();
@@ -36,6 +37,7 @@ public class SimplePathOptionsFormatterTest {
             "POST /aaa/fizz => fizz.buzz.Action#postMethod" + lineSeparator +
             "PUT /aaa/fizz => fizz.buzz.Action#putMethod" + lineSeparator +
             "GET /bbb/foo/(:param1) => foo.bar.Action#getMethod" + lineSeparator +
+            "PATCH /ccc/hoge => hoge.fuga.Action#patchMethod" + lineSeparator +
             "PUT /ccc/hoge => hoge.fuga.Action#putMethod"
         ));
     }

--- a/src/test/java/nablarch/integration/router/jaxrs/JaxRsResourceFinderTest.java
+++ b/src/test/java/nablarch/integration/router/jaxrs/JaxRsResourceFinderTest.java
@@ -60,9 +60,6 @@ public class JaxRsResourceFinderTest {
             hasProperty("name", is("patch")),
             hasProperty("name", is("myHttpMethod"))
         ));
-        assertThat(jaxRsResource.getResourceMethodList(), not(contains(
-                hasProperty("name", is("notAnnotated"))
-        )));
     }
     
     @Test

--- a/src/test/java/nablarch/integration/router/jaxrs/JaxRsResourceFinderTest.java
+++ b/src/test/java/nablarch/integration/router/jaxrs/JaxRsResourceFinderTest.java
@@ -57,8 +57,12 @@ public class JaxRsResourceFinderTest {
         assertThat(jaxRsResource.getResourceMethodList(), containsInAnyOrder(
             hasProperty("name", is("get")),
             hasProperty("name", is("post")),
+            hasProperty("name", is("patch")),
             hasProperty("name", is("myHttpMethod"))
         ));
+        assertThat(jaxRsResource.getResourceMethodList(), not(contains(
+                hasProperty("name", is("notAnnotated"))
+        )));
     }
     
     @Test

--- a/src/test/java/nablarch/integration/router/jaxrs/JaxRsRouterConverterTest.java
+++ b/src/test/java/nablarch/integration/router/jaxrs/JaxRsRouterConverterTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.PATCH;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -138,16 +139,21 @@ public class JaxRsRouterConverterTest {
             @PUT
             @Path("put-method")
             void put() {}
+
+            @PATCH
+            @Path("patch-method")
+            void patch() {}
         }
 
         JaxRsRouterConverter sut = new JaxRsRouterConverter("test");
 
-        List<PathOptions> pathOptionsList = sut.parse(jaxRsResource(TestResource.class, "get", "post", "put"));
+        List<PathOptions> pathOptionsList = sut.parse(jaxRsResource(TestResource.class, "get", "post", "put", "patch"));
 
         assertThat(pathOptionsList, containsInAnyOrder(
             hasProperty("path", is("test/test-resource/get-method")),
             hasProperty("path", is("test/test-resource/post-method")),
-            hasProperty("path", is("test/test-resource/put-method"))
+            hasProperty("path", is("test/test-resource/put-method")),
+            hasProperty("path", is("test/test-resource/patch-method"))
         ));
     }
     

--- a/src/test/java/nablarch/integration/router/jaxrs/test/JaxRsResourceFinderTest/testFindResourceMethods/ResourceClass.java
+++ b/src/test/java/nablarch/integration/router/jaxrs/test/JaxRsResourceFinderTest/testFindResourceMethods/ResourceClass.java
@@ -1,6 +1,7 @@
 package nablarch.integration.router.jaxrs.test.JaxRsResourceFinderTest.testFindResourceMethods;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.PATCH;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 
@@ -11,6 +12,9 @@ public class ResourceClass {
 
     @POST
     private void post() {}
+
+    @PATCH
+    public void patch() {}
 
     public void notAnnotated() {}
 

--- a/src/test/resources/routes.xml
+++ b/src/test/resources/routes.xml
@@ -2,5 +2,6 @@
   <root to="RoutesMappingTest#root"/>
   <get  path="method" to="RoutesMappingTest#get"/>
   <post path="method" to="RoutesMappingTest#post"/>
+  <patch path="method" to="RoutesMappingTest#patch"/>
   <match path=":controller/:action/:id" />
 </routes>


### PR DESCRIPTION
やったこと
- `@PATCH`が使えるようJAX-RSのバージョンを最新2.1.1に変更
(2.1.2以降はjakartaパッケージのため2.1.1を採用)
- `＠PATCH`で修飾したメソッドがルーティング対象として`JaxRsResourceFinder`で収集されることを確認
- `＠PATCH`で修飾したメソッドがルーティング対象として`JaxRsRouterConverter`でルーティング定義に変換されることを確認
- `@Path`によるルーティング定義ではなく`routes.xml`によるルーティング定義でも`PATCH`メソッドが扱えることを確認