### PR TITLE
公開APIを追加

### DIFF
--- a/src/main/java/nablarch/integration/router/PathOptions.java
+++ b/src/main/java/nablarch/integration/router/PathOptions.java
@@ -1,5 +1,6 @@
 package nablarch.integration.router;
 
+import nablarch.core.util.annotation.Published;
 import net.unit8.http.router.Options;
 
 /**
@@ -7,6 +8,7 @@ import net.unit8.http.router.Options;
  *
  * @author Tanaka Tomoyuki
  */
+@Published(tag = "architect")
 public class PathOptions {
     private final String path;
     private final Options options;

--- a/src/main/java/nablarch/integration/router/PathOptionsFormatter.java
+++ b/src/main/java/nablarch/integration/router/PathOptionsFormatter.java
@@ -1,5 +1,7 @@
 package nablarch.integration.router;
 
+import nablarch.core.util.annotation.Published;
+
 import java.util.List;
 
 /**
@@ -7,6 +9,7 @@ import java.util.List;
  *
  * @author Tanaka Tomoyuki
  */
+@Published(tag = "architect")
 public interface PathOptionsFormatter {
 
     /**

--- a/src/test/java/nablarch/integration/router/RoutesMappingTest.java
+++ b/src/test/java/nablarch/integration/router/RoutesMappingTest.java
@@ -14,7 +14,6 @@ import nablarch.fw.web.HttpRequest;
 import nablarch.fw.web.HttpResponse;
 import nablarch.fw.web.handler.MethodBinderFactory;
 import nablarch.fw.web.servlet.HttpRequestWrapper;
-import nablarch.fw.web.servlet.NablarchHttpServletRequestWrapper;
 import nablarch.fw.web.servlet.ServletExecutionContext;
 import nablarch.integration.router.sub.SubRoutesMappingTestAction;
 import net.unit8.http.router.RoutingException;

--- a/src/test/java/nablarch/integration/router/RoutesMethodBinderTest.java
+++ b/src/test/java/nablarch/integration/router/RoutesMethodBinderTest.java
@@ -9,7 +9,6 @@ import nablarch.fw.web.servlet.HttpRequestWrapper;
 import nablarch.fw.web.servlet.ServletExecutionContext;
 import org.junit.Test;
 
-import javax.servlet.Servlet;
 import javax.servlet.http.HttpServletRequest;
 
 import static org.hamcrest.CoreMatchers.is;


### PR DESCRIPTION
[解説書](https://nablarch.github.io/docs/5u24/doc/application_framework/adaptors/router_adaptor.html#id10)では、ルーティング定義のログ出力フォーマット変更のために`PathOptionsFormatter`の実装を案内しているものの、公開APIとはなっていなかったため、アーキテクト向けの公開APIとしました。
あわせて、実装に必要な`PathOptions`もアーキテクト向けの公開APIとしました。