### PR TITLE
sastruts-advanced-routesの記載修正

### DIFF
--- a/src/test/java/nablarch/integration/router/RoutesMappingTest.java
+++ b/src/test/java/nablarch/integration/router/RoutesMappingTest.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.fail;
  * {@link NablarchControllerDetector}も合わせてテストします。
  * <p>
  * ルーティングライブラリの仕様は以下を見てください。<br>
- * https://github.com/kawasima/sastruts-advanced-routes/blob/master/README.ja.md
+ * https://github.com/kawasima/http-request-router/blob/master/README.ja.md
  */
 public class RoutesMappingTest {
 


### PR DESCRIPTION
Nablarchが依存していない [sastruts-advanced-routes](https://github.com/kawasima/sastruts-advanced-routes/tree/master) への参照を発見したため、適切な記載に修正した。